### PR TITLE
Füge CP-SAT-Modell hinzu

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,12 +17,15 @@ repos:
       - id: pyright
         language_version: python3.12
         types: [python]
+        additional_dependencies: [ortools]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.7.1
     hooks:
       - id: mypy
         language_version: python3.12
         types: [python]
+        args: ["--ignore-missing-imports"]
+        additional_dependencies: [ortools]
   - repo: https://github.com/jendrikseipp/vulture
     rev: v2.10
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Diese Vorgaben gelten für das gesamte Repository.
 - Frühere Einträge niemals entfernen.
 
 ## Offene Punkte
-- Algorithmus zur Raumverteilung fehlt.
+- Algorithmus zur Raumverteilung unvollständig (Optimierung, Nichtüberlappung usw. fehlen).
 - Validator deckt noch nicht alle Spezialfälle ab (z. B. diagonale Engstellen).
 - Logging und Fortschrittsanzeige gemäß Spezifikation ausbauen.
 - Tests für Geometrie und Validierung erweitern.
@@ -43,3 +43,4 @@ Diese Vorgaben gelten für das gesamte Repository.
 - 2024-06-02: Grundgerüst (CLI, Konfigurationsladen, Dummy-Solver, Visualisierung, einfache Validierung) erstellt.
 - 2024-06-03: Validator erweitert (Überschneidungen, Gangbreite, Türen, Erreichbarkeit) und Tests ergänzt.
 - 2025-08-03: Prozessdokumentation, Pre-Commit-Konfiguration und Pyproject ergänzt.
+- 2025-08-03: Solver um CP-SAT-Grundgerüst und Randbedingungen erweitert.

--- a/Prozess.md
+++ b/Prozess.md
@@ -22,9 +22,9 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 ## Schritt-für-Schritt-Aufgabenliste
 1. Projekt mit Python ≥ 3.10 initialisieren (Quelle: AGENTS.md#12) – ✔ erledigt
 2. Konfigurationsdaten aus `rooms.yaml` laden (Quelle: README-SPEC.md#34-35) – ✔ erledigt
-3. CpModel und Variablen `x,y,w,h` pro Raum definieren (Quelle: README-SPEC.md#9) – ✖ offen
-4. Eingangsbereich als stets freien Gang modellieren (Quelle: README.md#41-45; README-SPEC.md#15) – ✖ offen
-5. Rand- und Rastergrenzen (`x+w≤77`, `y+h≤50`) absichern (Quelle: README-SPEC.md#36) – ✖ offen
+3. CpModel und Variablen `x,y,w,h` pro Raum definieren (Quelle: README-SPEC.md#9) – ✔ erledigt
+4. Eingangsbereich als stets freien Gang modellieren (Quelle: README.md#41-45; README-SPEC.md#15) – ✔ erledigt
+5. Rand- und Rastergrenzen (`x+w≤77`, `y+h≤50`) absichern (Quelle: README-SPEC.md#36) – ✔ erledigt
 6. Nichtüberlappung durch Lage-Binärvariablen erzwingen (Quelle: README-SPEC.md#19) – ✖ offen
 7. Mindest‑Gangbreite ≥4 überall sicherstellen (Quelle: README.md#91-98; README-SPEC.md#21) – ✖ offen
 8. Gang-Konnektivität via Flussmodell herstellen (Quelle: README-SPEC.md#23) – ✖ offen
@@ -57,9 +57,10 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | Aufgabe                                     | Status | Letzte Änderung        | Verantwortlich |
 |---------------------------------------------|:------:|------------------------|----------------|
 | Prozessdokumentation aufsetzen              | ✔     | 2025-08-03T21:25:34Z   | Agent          |
-| Algorithmus zur Raumverteilung implementieren| ✖     | 2025-08-03T21:25:34Z   | Agent          |
+| Algorithmus zur Raumverteilung implementieren| ✖     | 2025-08-03T21:40:00Z   | Agent          |
 | Logging & Fortschrittsanzeige ausbauen      | ✖     | 2025-08-03T21:25:34Z   | Agent          |
 | Tests erweitern                             | ✖     | 2025-08-03T21:25:34Z   | Agent          |
 
 ## Change-Log
 - 2025-08-03T21:25:34Z – Initiale Prozessbeschreibung erstellt
+- 2025-08-03T21:40:00Z – CP-SAT-Variablen und Randbedingungen implementiert

--- a/README.md
+++ b/README.md
@@ -475,5 +475,6 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 ## Fortschritt
 
 * 2024-06-01: AGENTS.md hinzugefügt und grundlegende Projektanweisungen dokumentiert.
-* 2024-06-02: Grundgerüst in Python erstellt (CLI, Konfigurationsladen, Dummy-Lösung, Visualisierung, Validierung, Tests).* 
+* 2024-06-02: Grundgerüst in Python erstellt (CLI, Konfigurationsladen, Dummy-Lösung, Visualisierung, Validierung, Tests).*
 * 2024-06-03: Validator erweitert (Überschneidungen, Gangbreite, Türen, Erreichbarkeit) und Tests ergänzt.
+* 2025-08-03: CP-SAT-Modell mit Variablen und Randbedingungen eingeführt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[project]
+name = "wands"
+version = "0.0.0"
+requires-python = ">=3.10"
+dependencies = ["ortools>=9.14", "pillow>=11.3"]
+
 [tool.ruff]
 line-length = 88
 extend-select = ["I"]

--- a/wands/solver.py
+++ b/wands/solver.py
@@ -1,39 +1,89 @@
-"""Dummy solver producing an empty solution.
+"""Simplified CP-SAT based solver.
 
-This module provides a placeholder implementation that merely returns the
-fixed entrance block without placing any rooms. It exists to demonstrate the
-expected I/O flow of the application.
+The current implementation builds a CP-SAT model that reserves the fixed
+entrance block and ensures that rooms stay within the 77×50 grid. It does not
+yet optimise or avoid room overlap but lays the foundation for further
+development.
 """
 
 from __future__ import annotations
 
-import random
 from typing import List
+
+from ortools.sat.python import cp_model
 
 from .model import Entrance, RoomDef
 
+GRID_W = 77
+GRID_H = 50
+
 
 def solve(room_defs: List[RoomDef], seed: int | None = None) -> dict:
-    """Return a trivial solution without rooms.
+    """Solve the room placement problem with minimal constraints.
 
     Parameters
     ----------
     room_defs:
-        The list of room definitions (currently unused).
+        The list of room definitions to place.
     seed:
         Optional RNG seed for deterministic behaviour.
     """
+    model = cp_model.CpModel()
+    solver = cp_model.CpSolver()
     if seed is not None:
-        random.seed(seed)
+        solver.parameters.random_seed = seed
+
     entrance = Entrance()
+    variables = []
+    for idx, rdef in enumerate(room_defs):
+        x = model.new_int_var(0, GRID_W - rdef.min_w, f"x_{idx}")
+        y = model.new_int_var(0, GRID_H - rdef.min_h, f"y_{idx}")
+        w = model.new_int_var(rdef.min_w, rdef.pref_w, f"w_{idx}")
+        h = model.new_int_var(rdef.min_h, rdef.pref_h, f"h_{idx}")
+        model.add(x + w <= GRID_W)
+        model.add(y + h <= GRID_H)
+
+        left = model.new_bool_var(f"left_{idx}")
+        right = model.new_bool_var(f"right_{idx}")
+        below = model.new_bool_var(f"below_{idx}")
+        above = model.new_bool_var(f"above_{idx}")
+        model.add(x + w <= entrance.x1).only_enforce_if(left)
+        model.add(x >= entrance.x2).only_enforce_if(right)
+        model.add(y + h <= entrance.y1).only_enforce_if(below)
+        model.add(y >= entrance.y2).only_enforce_if(above)
+        model.add_bool_or([left, right, below, above])
+        variables.append((rdef, x, y, w, h))
+
+    status = solver.solve(model)
+    rooms = []
+    area_total = 0
+    if status in (cp_model.OPTIMAL, cp_model.FEASIBLE):
+        for rdef, x, y, w, h in variables:
+            vx = solver.value(x)
+            vy = solver.value(y)
+            vw = solver.value(w)
+            vh = solver.value(h)
+            rooms.append(
+                {
+                    "id": rdef.name,
+                    "type": rdef.group,
+                    "x": vx,
+                    "y": vy,
+                    "w": vw,
+                    "h": vh,
+                    "doors": [],
+                }
+            )
+            area_total += vw * vh
+
     solution = {
-        "rooms": [],
+        "rooms": rooms,
         "entrance": {
             "x1": entrance.x1,
             "x2": entrance.x2,
             "y1": entrance.y1,
             "y2": entrance.y2,
         },
-        "objective": {"room_area_total": 0},
+        "objective": {"room_area_total": area_total},
     }
     return solution


### PR DESCRIPTION
## Zusammenfassung
- Implementiere ein erstes CP-SAT-Modell mit Raumvariablen, Randbedingungen und frei gehaltenem Eingang.
- Dokumentiere die benötigten Abhängigkeiten in `pyproject.toml` und passe Pre-Commit-Konfiguration für Typprüfungen an.
- Aktualisiere Prozess- und Projektunterlagen mit Fortschrittseinträgen.

## Test
- `ruff check wands/solver.py`
- `pyright wands/solver.py`
- `mypy --ignore-missing-imports wands/solver.py`
- `vulture wands/solver.py`
- `xenon wands/solver.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd6b4ffd48327a762677bd2bfd25f