### PR TITLE
Prozessstarter-Skript hinzufügen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,4 @@ Diese Vorgaben gelten für das gesamte Repository.
 - 2024-06-03: Validator erweitert (Überschneidungen, Gangbreite, Türen, Erreichbarkeit) und Tests ergänzt.
 - 2025-08-03: Prozessdokumentation, Pre-Commit-Konfiguration und Pyproject ergänzt.
 - 2025-08-03: Solver um CP-SAT-Grundgerüst und Randbedingungen erweitert.
+- 2025-08-04: Prozessstarter `start_process.py` eingeführt.

--- a/Prozess.md
+++ b/Prozess.md
@@ -39,6 +39,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 17. Sauberen Abbruch und optionale Checkpoints unterstützen (Quelle: README.md#447-450; README-SPEC.md#91) – ✖ offen
 18. Validierung aller Muss-Kriterien implementieren (Quelle: README.md#15-20; README-SPEC.md#57-77) – ✔ erledigt
 19. Tests für Geometrie und Validierung erweitern (Quelle: AGENTS.md#17; README.md#475-479) – ✖ offen
+20. Prozessstarter-Skript `start_process.py` mit Standardpfaden bereitstellen – ✔ erledigt
 
 ## Parameter- & Optionsreferenz
 - Rastergröße `GRID_W=77`, `GRID_H=50` (Quelle: README.md#115-118)
@@ -60,7 +61,9 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | Algorithmus zur Raumverteilung implementieren| ✖     | 2025-08-03T21:40:00Z   | Agent          |
 | Logging & Fortschrittsanzeige ausbauen      | ✖     | 2025-08-03T21:25:34Z   | Agent          |
 | Tests erweitern                             | ✖     | 2025-08-03T21:25:34Z   | Agent          |
+| Prozessstarter-Skript hinzufügen            | ✔     | 2025-08-04T00:00:00Z   | Agent          |
 
 ## Change-Log
 - 2025-08-03T21:25:34Z – Initiale Prozessbeschreibung erstellt
 - 2025-08-03T21:40:00Z – CP-SAT-Variablen und Randbedingungen implementiert
+- 2025-08-04T00:00:00Z – Prozessstarter-Skript hinzugefügt

--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ grundstueck_77x50_eingang_4x10.png ist im Hauptverzeichnis, so sieht das Grundst
 ---
 Vor diesen punkten immer README-SPEC.md und AGENT_AUFTRAG.md lesen!
 
+Der komplette Prozess lässt sich mit Standardpfaden über das Skript
+``start_process.py`` starten:
+
+```bash
+python start_process.py --progress off
+```
+
+Weitere unbekannte Parameter werden an die interne CLI von `wands`
+weitergereicht.
+
 ## 1) Ziel & Problemkurzbeschreibung
 
 Entwirf ein Python-Programm, das für ein rechteckiges, diskretes Grundstück (Gitternetz) eine **optimale Raumverteilung** berechnet.
@@ -478,3 +488,4 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * 2024-06-02: Grundgerüst in Python erstellt (CLI, Konfigurationsladen, Dummy-Lösung, Visualisierung, Validierung, Tests).*
 * 2024-06-03: Validator erweitert (Überschneidungen, Gangbreite, Türen, Erreichbarkeit) und Tests ergänzt.
 * 2025-08-03: CP-SAT-Modell mit Variablen und Randbedingungen eingeführt.
+* 2025-08-04: Prozessstarter-Skript `start_process.py` hinzugefügt.

--- a/start_process.py
+++ b/start_process.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+"""Convenience script to run the full Wands process.
+
+This wrapper supplies default paths so the solver, validator and renderer
+can be executed with a single command. Additional arguments are forwarded
+to the underlying :mod:`wands.cli` interface.
+"""
+
+import argparse
+import sys
+from typing import Sequence
+
+from wands.cli import main as wands_main
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    """Parse arguments and execute the Wands pipeline.
+
+    Parameters
+    ----------
+    argv:
+        Optional argument list. If ``None`` the arguments from ``sys.argv``
+        are used.
+    """
+    parser = argparse.ArgumentParser(description="Start the Wands process")
+    parser.add_argument(
+        "--config",
+        default="rooms.yaml",
+        help="Path to the rooms configuration file.",
+    )
+    parser.add_argument(
+        "--out-json",
+        default="solution.json",
+        help="Output path for the solution JSON.",
+    )
+    parser.add_argument(
+        "--out-png",
+        default="solution.png",
+        help="Output path for the solution visualisation PNG.",
+    )
+    parser.add_argument(
+        "--validate",
+        default="validation_report.json",
+        dest="report",
+        help="Output path for the validation report JSON.",
+    )
+    known, unknown = parser.parse_known_args(argv)
+    args = [
+        "--config",
+        known.config,
+        "--out-json",
+        known.out_json,
+        "--out-png",
+        known.out_png,
+        "--validate",
+        known.report,
+    ] + unknown
+    return wands_main(args)
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from wands import __version__
 
 
 def test_cli_creates_output(tmp_path: Path) -> None:
@@ -32,3 +36,13 @@ def test_cli_creates_output(tmp_path: Path) -> None:
     assert out_report.exists(), "validation report not created"
     data = json.loads(out_json.read_text())
     assert data["entrance"]["x1"] == 56
+
+
+def test_start_process_version() -> None:
+    result = subprocess.run(
+        [sys.executable, "start_process.py", "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert __version__ in result.stdout


### PR DESCRIPTION
## Zusammenfassung
- CLI-Prozessstarter `start_process.py` erstellt, der Standardpfade nutzt und alle weiteren Argumente an die vorhandene `wands`-CLI weitergibt.
- README ergänzt und Fortschritt dokumentiert.
- Tests aktualisiert und neues Szenario für den Prozessstarter hinzugefügt.

## Testen
- `ruff check start_process.py tests/test_cli.py`
- `pyright start_process.py tests/test_cli.py`
- `vulture start_process.py tests/test_cli.py`
- `xenon --max-absolute B --max-modules B --max-average A start_process.py tests/test_cli.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fd97572a88327a51d4984634ad9be