### PR TITLE
Version auf 1.0.0 setzen und Datenmodelle ergänzen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,3 +45,4 @@ Diese Vorgaben gelten für das gesamte Repository.
 - 2025-08-03: Prozessdokumentation, Pre-Commit-Konfiguration und Pyproject ergänzt.
 - 2025-08-03: Solver um CP-SAT-Grundgerüst und Randbedingungen erweitert.
 - 2025-08-04: Prozessstarter `start_process.py` eingeführt.
+- 2025-08-04: Datenmodelle `RoomPlacement` und `SolveParams` ergänzt.

--- a/Prozess.md
+++ b/Prozess.md
@@ -64,10 +64,12 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 18. Validierung aller Muss-Kriterien implementieren (Quelle: README.md#15-20; README-SPEC.md#57-77) – ✔ erledigt
 19. Tests für Geometrie und Validierung erweitern (Quelle: AGENTS.md#17; README.md#475-479) – ✖ offen
 20. Prozessstarter-Skript `start_process.py` mit Standardpfaden bereitstellen – ✔ erledigt
+21. Datenmodelle `RoomPlacement` und `SolveParams` ergänzen (Quelle: Benutzeranweisung) – ✔ erledigt
 
 ## Parameter- & Optionsreferenz
 - Rastergröße `GRID_W=77`, `GRID_H=50` (Quelle: README.md#115-118)
 - Eingang `x1=56`, `x2=60`, `y1=40`, `y2=50` (Quelle: README.md#41-45)
+- Korridorfenster `corridor_win=4` (Quelle: Benutzeranweisung)
 - CLI: `--log-level {DEBUG,INFO,WARN,ERROR}` (Quelle: README.md#411)
 - CLI: `--log-format {text,json}` (Quelle: README.md#412)
 - CLI: `--log-file <pfad>` (Quelle: README.md#413)
@@ -86,9 +88,11 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | Logging & Fortschrittsanzeige ausbauen      | ✖     | 2025-08-03T21:25:34Z   | Agent          |
 | Tests erweitern                             | ✖     | 2025-08-03T21:25:34Z   | Agent          |
 | Prozessstarter-Skript hinzufügen            | ✔     | 2025-08-04T00:00:00Z   | Agent          |
+| Datenmodelle für RoomPlacement/SolveParams ergänzen | ✔     | 2025-08-04T01:00:00Z   | Agent          |
 
 ## Change-Log
 - 2025-08-03T21:25:34Z – Initiale Prozessbeschreibung erstellt
 - 2025-08-03T21:40:00Z – CP-SAT-Variablen und Randbedingungen implementiert
 - 2025-08-03T22:05:52Z – Zehn-Schritte-Ablauf und Idempotenzregeln ergänzt
 - 2025-08-04T00:00:00Z – Prozessstarter-Skript hinzugefügt
+- 2025-08-04T01:00:00Z – Datenmodelle für RoomPlacement und SolveParams ergänzt

--- a/README.md
+++ b/README.md
@@ -506,3 +506,4 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * 2025-08-03: CP-SAT-Modell mit Variablen und Randbedingungen eingeführt.
 * 2025-08-03: Kurz-Spezifikation, CLI-Beispiel und Abhängigkeiten ergänzt.
 * 2025-08-04: Prozessstarter-Skript `start_process.py` hinzugefügt.
+* 2025-08-04: Datenmodelle für RoomPlacement und SolveParams ergänzt.

--- a/wands/__init__.py
+++ b/wands/__init__.py
@@ -1,4 +1,4 @@
 """Wands package providing room planning utilities."""
 
 __all__ = ["__version__"]
-__version__ = "0.1.0"
+__version__ = "1.0.0"

--- a/wands/model.py
+++ b/wands/model.py
@@ -16,8 +16,8 @@ class Door:
 
 
 @dataclass
-class Room:
-    """Placed room with doors."""
+class RoomPlacement:
+    """A concrete placement of a room in the grid."""
 
     id: str
     type: str
@@ -53,3 +53,27 @@ class RoomDef:
     priority: int
     efficiency_factor: float
     duplicate_id: Optional[str] = None
+
+
+@dataclass
+class SolveParams:
+    """Solver parameters and fixed problem constants."""
+
+    grid_w: int = 77
+    grid_h: int = 50
+    entrance_x: int = 56
+    entrance_w: int = 4
+    entrance_y: int = 40
+    entrance_h: int = 10
+    corridor_win: int = 4
+    max_iters: int = 1000
+    log_every: int = 100
+
+    def entrance_bounds(self) -> tuple[int, int, int, int]:
+        """Return entrance bounds as ``(x1, x2, y1, y2)``."""
+
+        x1 = self.entrance_x
+        x2 = self.entrance_x + self.entrance_w
+        y1 = self.entrance_y
+        y2 = self.entrance_y + self.entrance_h
+        return x1, x2, y1, y2


### PR DESCRIPTION
## Zusammenfassung
- Setzt die Paketversion in `wands.__init__` auf 1.0.0.
- Führt `RoomPlacement`- und `SolveParams`-Datenklassen mit Standardparametern und `entrance_bounds`-Helfer ein.
- Protokolliert die Änderungen in Prozess- und Projektdokumentation.

## Testing
- `ruff check wands/__init__.py wands/model.py README.md Prozess.md AGENTS.md`
- `pyright`
- `ruff check --select F401 wands`
- `radon cc wands -n B`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fde775718832783359ad391d9fa6b