### PR TITLE
Implementiere Fortschrittsmodul mit Heartbeat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,4 @@ Diese Vorgaben gelten für das gesamte Repository.
 - 2025-08-04: Prozessstarter `start_process.py` eingeführt.
 - 2025-08-04: Datenmodelle `RoomPlacement` und `SolveParams` ergänzt.
 - 2025-08-04: Hilfsfunktionen für Rasteroperationen hinzugefügt.
+- 2025-08-04: Fortschrittsmodul mit Heartbeat und Abschluss implementiert.

--- a/Prozess.md
+++ b/Prozess.md
@@ -65,6 +65,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 19. Tests für Geometrie und Validierung erweitern (Quelle: AGENTS.md#17; README.md#475-479) – ✖ offen
 20. Prozessstarter-Skript `start_process.py` mit Standardpfaden bereitstellen – ✔ erledigt
 21. Datenmodelle `RoomPlacement` und `SolveParams` ergänzen (Quelle: Benutzeranweisung) – ✔ erledigt
+22. Fortschrittsmodul für Heartbeat implementieren (Quelle: Benutzeranweisung) – ✔ erledigt
 
 ## Parameter- & Optionsreferenz
 - Rastergröße `GRID_W=77`, `GRID_H=50` (Quelle: README.md#115-118)
@@ -85,7 +86,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 |---------------------------------------------|:------:|------------------------|----------------|
 | Prozessdokumentation aufsetzen              | ✔     | 2025-08-03T22:05:52Z   | Agent          |
 | Algorithmus zur Raumverteilung implementieren| ✖     | 2025-08-03T21:40:00Z   | Agent          |
-| Logging & Fortschrittsanzeige ausbauen      | ✖     | 2025-08-03T21:25:34Z   | Agent          |
+| Logging & Fortschrittsanzeige ausbauen      | ✖     | 2025-08-04T03:00:00Z   | Agent          |
 | Tests erweitern                             | ✖     | 2025-08-03T21:25:34Z   | Agent          |
 | Prozessstarter-Skript hinzufügen            | ✔     | 2025-08-04T00:00:00Z   | Agent          |
 | Datenmodelle für RoomPlacement/SolveParams ergänzen | ✔     | 2025-08-04T01:00:00Z   | Agent          |
@@ -97,3 +98,4 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - 2025-08-04T00:00:00Z – Prozessstarter-Skript hinzugefügt
 - 2025-08-04T01:00:00Z – Datenmodelle für RoomPlacement und SolveParams ergänzt
 - 2025-08-04T02:00:00Z – Hilfsfunktionen für Rasteroperationen und Tests ergänzt
+- 2025-08-04T03:00:00Z – Fortschrittsmodul mit Heartbeat und Abschluss implementiert

--- a/README.md
+++ b/README.md
@@ -508,3 +508,4 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * 2025-08-04: Prozessstarter-Skript `start_process.py` hinzugefügt.
 * 2025-08-04: Datenmodelle für RoomPlacement und SolveParams ergänzt.
 * 2025-08-04: Hilfsfunktionen für Rasteroperationen und entsprechende Tests ergänzt.
+* 2025-08-04: Fortschrittsmodul für Heartbeat-Logging hinzugefügt.

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,33 @@
+"""Tests for the progress module."""
+
+import io
+import json
+
+from wands.progress import Progress, ProgressEvent
+
+
+def test_progress_event_creation():
+    """ProgressEvent stores provided data."""
+    event = ProgressEvent(ts="0", phase="solve", runtime_sec=1.0, vars=10)
+    assert event.phase == "solve"
+    assert event.vars == 10
+
+def test_progress_text_and_interval():
+    """Heartbeat respects interval and emits final event."""
+    buf = io.StringIO()
+    prog = Progress(stream=buf, fmt="text", interval=1)
+    prog.heartbeat("solve", objective_best=1.0)
+    first = buf.getvalue()
+    prog.heartbeat("solve", objective_best=2.0)
+    assert buf.getvalue() == first
+    prog.done("finish")
+    assert "finish" in buf.getvalue().splitlines()[-1]
+
+def test_progress_json_output():
+    """JSON format produces serializable output."""
+    buf = io.StringIO()
+    prog = Progress(stream=buf, fmt="json", interval=0)
+    prog.heartbeat("start", vars=3)
+    data = json.loads(buf.getvalue())
+    assert data["phase"] == "start"
+    assert data["vars"] == 3

--- a/wands/progress.py
+++ b/wands/progress.py
@@ -1,0 +1,96 @@
+"""Progress reporting utilities."""
+
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Any, Optional, TextIO
+
+
+@dataclass
+class ProgressEvent:
+    """Represents a progress update for the solving process."""
+
+    ts: str
+    phase: str
+    runtime_sec: float
+    eta_sec: Optional[float] = None
+    objective_best: Optional[float] = None
+    objective_bound: Optional[float] = None
+    gap: Optional[float] = None
+    vars: Optional[int] = None
+    constraints: Optional[int] = None
+    mem_mb: Optional[float] = None
+    note: Optional[str] = None
+
+
+class Progress:
+    """Emit progress updates in text or JSON lines format."""
+
+    def __init__(
+        self,
+        stream: Optional[TextIO] = None,
+        fmt: str = "text",
+        interval: float = 1.0,
+    ) -> None:
+        """Initialize the progress reporter."""
+        self.stream = stream if stream is not None else sys.stdout
+        self.fmt = fmt
+        self.interval = interval
+        self._start = time.time()
+        self._last = 0.0
+
+    def _write(self, event: ProgressEvent) -> None:
+        if self.fmt == "json":
+            self.stream.write(json.dumps(asdict(event), ensure_ascii=False) + "\n")
+        else:
+            parts = [
+                event.ts,
+                event.phase,
+                f"t={event.runtime_sec:.3f}s",
+            ]
+            if event.eta_sec is not None:
+                parts.append(f"eta={event.eta_sec:.3f}s")
+            if event.objective_best is not None:
+                parts.append(f"best={event.objective_best}")
+            if event.objective_bound is not None:
+                parts.append(f"bound={event.objective_bound}")
+            if event.gap is not None:
+                parts.append(f"gap={event.gap}")
+            if event.vars is not None:
+                parts.append(f"vars={event.vars}")
+            if event.constraints is not None:
+                parts.append(f"cons={event.constraints}")
+            if event.mem_mb is not None:
+                parts.append(f"mem={event.mem_mb:.1f}MB")
+            if event.note:
+                parts.append(event.note)
+            self.stream.write(" ".join(parts) + "\n")
+        self.stream.flush()
+
+    def heartbeat(self, phase: str, **data: Any) -> None:
+        """Emit a progress event if the interval has elapsed."""
+        now = time.time()
+        if now - self._last < self.interval:
+            return
+        self._last = now
+        event = ProgressEvent(
+            ts=datetime.utcnow().isoformat(),
+            phase=phase,
+            runtime_sec=now - self._start,
+            **data,
+        )
+        self._write(event)
+
+    def done(self, phase: str = "finish", **data: Any) -> None:
+        """Emit a final progress event without interval restriction."""
+        now = time.time()
+        self._last = now
+        event = ProgressEvent(
+            ts=datetime.utcnow().isoformat(),
+            phase=phase,
+            runtime_sec=now - self._start,
+            **data,
+        )
+        self._write(event)


### PR DESCRIPTION
## Zusammenfassung
- Ergänzt `ProgressEvent`-Dataclass mit optionalen Metriken.
- Implementiert `Progress`-Klasse für Heartbeat- und Abschluss-Events in Text/JSON.
- Fügt Tests für Fortschrittsausgaben und Intervallsteuerung hinzu.
- Aktualisiert AGENTS-, README- und Prozessdokumentation.

## Testing
- `ruff check .` (fehlgeschlagen: zahlreiche bestehende Lint-Fehler)
- `pyright` (1 Warnung)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fe1f4b144832790520e5348f0206d