### PR TITLE
Ergänze CLI-Tests

### DIFF
--- a/Prozess.md
+++ b/Prozess.md
@@ -92,7 +92,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | Prozessdokumentation aufsetzen              | ✔     | 2025-08-03T22:05:52Z   | Agent          |
 | Algorithmus zur Raumverteilung implementieren| ✔     | 2025-08-05T00:00:00Z   | Agent          |
 | Logging & Fortschrittsanzeige ausbauen      | ✖     | 2025-08-04T03:00:00Z   | Agent          |
-| Tests erweitern                             | ✖     | 2025-08-04T00:24:03Z   | Agent          |
+| Tests erweitern                             | ✖     | 2025-08-06T02:00:00Z   | Agent          |
 | Prozessstarter-Skript hinzufügen            | ✔     | 2025-08-04T00:00:00Z   | Agent          |
 | Datenmodelle für RoomPlacement/SolveParams ergänzen | ✔     | 2025-08-04T01:00:00Z   | Agent          |
 | Visualisierung für solution.png implementieren | ✔     | 2025-08-04T00:12:49Z   | Agent          |
@@ -111,3 +111,4 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - 2025-08-05T00:00:00Z – CP-SAT-Solver mit Tür- und Konnektivitäts-Cuts implementiert
 - 2025-08-06T00:00:00Z – CLI um Grid- und Eingang-Parameter sowie Validierungsmodus erweitert
 - 2025-08-06T01:00:00Z – `rooms.yaml` auf Einzeilenformat gebracht und Lösungsschema ergänzt
+- 2025-08-06T02:00:00Z – CLI-Tests für Versionsausgabe und Minimalablauf hinzugefügt

--- a/README.md
+++ b/README.md
@@ -514,3 +514,4 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * 2025-08-05: CP-SAT-Solver mit Tür- und Konnektivitäts-Cuts implementiert.
 * 2025-08-06: CLI um Grid- und Eingang-Parameter sowie Validierung-only-Modus erweitert.
 * 2025-08-06: `rooms.yaml` auf Einzeilenformat umgestellt und JSON-Schema `schemas/solution.schema.json` ergänzt.
+* 2025-08-06: CLI-Tests für Versionsausgabe und Minimalablauf ergänzt.


### PR DESCRIPTION
## Zusammenfassung
- Teste `python -m wands --version` auf Exit-Code und Versionsstring.
- End-to-End-Test für `python -m wands` mit `rooms.yaml`, validiert Eingang und Artefakt-Erzeugung.
- Fortschritt und Prozessdokumentation aktualisiert.

## Testanweisungen
- `ruff check tests/test_cli.py`
- `pyright` (schlägt fehl)
- `mypy .` (schlägt fehl)
- `vulture .`
- `xenon . --max-absolute B --max-modules B --max-average B` (liefert Komplexitätsfehler)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68904415f9e083279875d622a4f32866