### PR TITLE
Leitfaden für Google Colab hinzufügen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,4 @@ Keine
 - 2025-08-07: Logging, Fortschrittsanzeige, Checkpoints und zusätzliche Tests ergänzt.
 - 2025-08-08: Validator um diagonale Engstellen/Türengpässe erweitert, Fortschrittsdaten aus Solver ergänzt.
 - 2025-08-09: requirements.txt mit Laufzeit- und Prüf-Abhängigkeiten ergänzt.
+- 2025-08-10: GUIDE.md mit Colab-Installations- und Startanleitung ergänzt.

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,0 +1,59 @@
+# GUIDE: Nutzung in Google Colab (Free Plan)
+
+## Installation
+
+1. Neues Notebook auf [Google Colab](https://colab.research.google.com) anlegen.
+2. Repository klonen und Arbeitsverzeichnis wechseln:
+   ```bash
+   !git clone <REPO_URL>
+   %cd Wands
+   ```
+3. Benötigte Pakete installieren:
+   ```bash
+   !pip install ortools pillow pyyaml
+   !pip install ruff pytest
+   ```
+
+## Start über die CLI
+
+Das Programm kann direkt über `python -m wands` gestartet werden. Alle Ausgaben werden in die angegebenen Dateien geschrieben.
+
+Nachfolgend sind Beispielbefehle für drei Laufzeitlimits (1 min, 10 min, 30 min) angegeben. Für jede Laufzeit gibt es eine Variante mit minimaler und maximaler Rechenlast.
+
+### 1 Minute
+
+**Minimale Rechenlast**
+```bash
+!python -m wands --config rooms.yaml --out-json solution.json --out-png solution.png --validate validation_report.json --time-limit 60 --threads 1 --progress off
+```
+
+**Maximale Rechenlast**
+```bash
+!python -m wands --config rooms.yaml --out-json solution.json --out-png solution.png --validate validation_report.json --time-limit 60 --threads 2 --progress auto
+```
+
+### 10 Minuten
+
+**Minimale Rechenlast**
+```bash
+!python -m wands --config rooms.yaml --out-json solution.json --out-png solution.png --validate validation_report.json --time-limit 600 --threads 1 --progress off
+```
+
+**Maximale Rechenlast**
+```bash
+!python -m wands --config rooms.yaml --out-json solution.json --out-png solution.png --validate validation_report.json --time-limit 600 --threads 2 --progress auto
+```
+
+### 30 Minuten
+
+**Minimale Rechenlast**
+```bash
+!python -m wands --config rooms.yaml --out-json solution.json --out-png solution.png --validate validation_report.json --time-limit 1800 --threads 1 --progress off
+```
+
+**Maximale Rechenlast**
+```bash
+!python -m wands --config rooms.yaml --out-json solution.json --out-png solution.png --validate validation_report.json --time-limit 1800 --threads 2 --progress auto
+```
+
+Die erzeugten Dateien `solution.json`, `solution.png` und `validation_report.json` erscheinen im aktuellen Arbeitsverzeichnis und können über das Dateimenü von Colab heruntergeladen werden.

--- a/Prozess.md
+++ b/Prozess.md
@@ -73,6 +73,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 25. Validator um diagonale Engstellen und Türengpässe erweitern – ✔ erledigt
 26. Fortschrittsdaten mit Bound/Gap/Vars/Constraints/Mem ergänzen – ✔ erledigt
 27. `requirements.txt` mit Abhängigkeiten erstellen (Quelle: Benutzeranweisung) – ✔ erledigt
+28. Anleitung für Nutzung in Google Colab (GUIDE.md) erstellen – ✔ erledigt
 
 ## Parameter- & Optionsreferenz
 - Rastergröße `GRID_W=77`, `GRID_H=50` (Quelle: README.md#115-118)
@@ -106,6 +107,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | Validator um diagonale Engstellen/Türengpässe erweitern | ✔     | 2025-08-08T00:00:00Z   | Agent          |
 | Fortschrittsdaten mit Bound/Gap/Vars/Constraints/Mem erweitern | ✔     | 2025-08-08T00:00:00Z   | Agent          |
 | `requirements.txt` für Abhängigkeiten erstellen | ✔     | 2025-08-09T00:00:00Z   | Agent          |
+| Dokumentation für Google-Colab-Nutzung schreiben | ✔     | 2025-08-10T00:00:00Z   | Agent          |
 
 ## Change-Log
 - 2025-08-03T21:25:34Z – Initiale Prozessbeschreibung erstellt
@@ -124,3 +126,4 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - 2025-08-07T00:00:00Z – Logging, Progress, Checkpoint-Unterstützung und zusätzliche Validierungs-Tests ergänzt
 - 2025-08-08T00:00:00Z – Validator um diagonale Engstellen/Türengpässe erweitert und Fortschrittsstatistiken ergänzt
 - 2025-08-09T00:00:00Z – requirements.txt mit Laufzeit- und Prüf-Abhängigkeiten ergänzt
+- 2025-08-10T00:00:00Z – GUIDE.md mit Colab-Installationsanleitung ergänzt

--- a/README.md
+++ b/README.md
@@ -519,3 +519,4 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * 2025-08-07: Logging/Progress ausgebaut, Checkpoints und zusätzliche Validator-Tests hinzugefügt.
 * 2025-08-08: Validator auf diagonale Engstellen/Türengpässe erweitert, Fortschrittsstatistiken ergänzt.
 * 2025-08-09: requirements.txt mit Laufzeit- und Prüf-Abhängigkeiten ergänzt.
+* 2025-08-10: GUIDE.md mit Anleitung für Google Colab hinzugefügt.


### PR DESCRIPTION
## Zusammenfassung
- Leitfaden `GUIDE.md` für Google Colab erstellt mit Installationsschritten sowie Beispielbefehlen für 1, 10 und 30 Minuten Laufzeit in minimaler und maximaler Rechenlast.
- `Prozess.md`, `AGENTS.md` und README um den neuen Leitfaden ergänzt.

## Tests
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910f21afd08327a3b2e7af7fd94b8f