### PR TITLE
Fixiere Abhängigkeiten für Colab

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -8,10 +8,9 @@
    !git clone <REPO_URL>
    %cd Wands
    ```
-3. Benötigte Pakete installieren:
+3. Abhängigkeiten aus der gepflegten `requirements.txt` installieren:
    ```bash
-   !pip install ortools pillow pyyaml
-   !pip install ruff pytest
+   !pip install -r requirements.txt
    ```
 
 ## Start über die CLI

--- a/Prozess.md
+++ b/Prozess.md
@@ -106,8 +106,8 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | JSON-Schema für solution.json bereitstellen | ✔     | 2025-08-06T01:00:00Z   | Agent          |
 | Validator um diagonale Engstellen/Türengpässe erweitern | ✔     | 2025-08-08T00:00:00Z   | Agent          |
 | Fortschrittsdaten mit Bound/Gap/Vars/Constraints/Mem erweitern | ✔     | 2025-08-08T00:00:00Z   | Agent          |
-| `requirements.txt` für Abhängigkeiten erstellen | ✔     | 2025-08-09T00:00:00Z   | Agent          |
-| Dokumentation für Google-Colab-Nutzung schreiben | ✔     | 2025-08-10T00:00:00Z   | Agent          |
+| `requirements.txt` für Abhängigkeiten erstellen | ✔     | 2025-08-10T02:00:00Z   | Agent          |
+| Dokumentation für Google-Colab-Nutzung schreiben | ✔     | 2025-08-10T02:00:00Z   | Agent          |
 
 ## Change-Log
 - 2025-08-03T21:25:34Z – Initiale Prozessbeschreibung erstellt
@@ -127,3 +127,4 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - 2025-08-08T00:00:00Z – Validator um diagonale Engstellen/Türengpässe erweitert und Fortschrittsstatistiken ergänzt
 - 2025-08-09T00:00:00Z – requirements.txt mit Laufzeit- und Prüf-Abhängigkeiten ergänzt
 - 2025-08-10T00:00:00Z – GUIDE.md mit Colab-Installationsanleitung ergänzt
+- 2025-08-10T02:00:00Z – requirements auf Colab-Version abgestimmt und GUIDE aktualisiert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,17 @@
-ortools>=9.14
-pillow>=11.3
-pyyaml>=6.0.2
-pytest>=8.4.1
-ruff>=0.9.3
-flake8>=7.3.0
-isort>=6.0.1
-pyright>=1.1.359
-mypy>=1.7.1
-vulture>=2.14
-xenon>=0.9.3
-radon>=6.0.1
-pre-commit>=4.2.0
-protobuf>=5.26.1,<6
+# Laufzeit (Repo "Wands")
+protobuf==5.29.5
+ortools==9.12.4544
+pillow==11.3.0
+pyyaml==6.0.2
+
+# Test & Code-Qualität
+pytest==8.4.1
+ruff==0.12.7
+flake8==7.3.0
+isort==6.0.1
+pyright==1.1.403
+mypy==1.11.2
+vulture==2.14
+xenon==0.9.3
+radon==6.0.1
+pre-commit==4.2.0


### PR DESCRIPTION
## Zusammenfassung
- pinne Laufzeit- und QA-Abhängigkeiten für Google Colab
- vereinfache Colab-Anleitung auf Installation via requirements.txt
- ergänze Prozessdokumentation um aktualisierte Zeitstempel und Change-Log

## Testing
- `ruff check .` *(fehlschläge: E501, I001)*
- `python -m flake8 .` *(fehlschläge: E501 u.a.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911246f9ac8327b3f36ff56f421054