### PR TITLE
Ergänze Datenklassen und mache Speicherlogging portabel

### DIFF
--- a/Prozess.md
+++ b/Prozess.md
@@ -77,6 +77,8 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 27. `requirements.txt` mit Abhängigkeiten erstellen (Quelle: Benutzeranweisung) – ✔ erledigt
 28. Anleitung für Nutzung in Google Colab (GUIDE.md) erstellen – ✔ erledigt
 29. Prüfroutine `AGENTS_Pruefung.md` hinzufügen – ✔ erledigt
+30. Datenklassen in `model.py` vervollständigen – ✔ erledigt
+31. Speicherlogging ohne `resource` ermöglichen – ✔ erledigt
 
 ## Parameter- & Optionsreferenz
 - Rastergröße `GRID_W=77`, `GRID_H=50` (Quelle: README.md#115-118)
@@ -112,6 +114,8 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | `requirements.txt` für Abhängigkeiten erstellen | ✔     | 2025-08-10T02:00:00Z   | Agent          |
 | Prüfroutine `AGENTS_Pruefung.md` hinzufügen | ✔     | 2025-08-11T01:00:00Z   | Agent          |
 | Dokumentation für Google-Colab-Nutzung schreiben | ✔     | 2025-08-10T02:00:00Z   | Agent          |
+| Datenklassen in model.py vervollständigen | ✔     | 2025-08-12T00:00:00Z   | Agent          |
+| Speicherlogging ohne resource ermöglichen | ✔     | 2025-08-12T00:00:00Z   | Agent          |
 
 ## Change-Log
 - 2025-08-03T21:25:34Z – Initiale Prozessbeschreibung erstellt
@@ -135,3 +139,4 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - 2025-08-11T00:00:00Z – Prüfroutine AGENTS_Pruefung.md hinzugefügt
 - 2025-08-11T01:00:00Z – Prüfroutine in AGENTS_Pruefung.md vervollständigt
 - 2025-08-11T02:00:00Z – Codeformatierung und Lintingfehler bereinigt
+- 2025-08-12T00:00:00Z – Datenklassen in model.py vervollständigt und Speicherlogging ohne resource implementiert

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,17 @@
+"""Tests for data model classes."""
+
+from wands.model import Door, Entrance, RoomDef, RoomPlacement, SolveParams
+
+
+def test_dataclass_instantiation() -> None:
+    """Basic instantiation and attribute access should work."""
+    door = Door("left", 1, 2)
+    placement = RoomPlacement("r1", "office", 0, 0, 3, 3, [door])
+    entrance = Entrance()
+    rdef = RoomDef("office", "g1", 3, 3, 2, 2, 1, 1, 1, 1.0)
+    params = SolveParams()
+
+    assert placement.doors == [door]
+    assert entrance.x2 - entrance.x1 == 4
+    assert rdef.name == "office"
+    assert params.grid_w == 77

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -2,6 +2,7 @@
 
 from wands import solver
 from wands.model import SolveParams
+from wands.progress import Progress
 
 
 def test_allowed_values() -> None:
@@ -26,4 +27,28 @@ def test_solve_basic() -> None:
         max_iters=2,
     )
     result = solver.solve([], params)
+    assert result["rooms"] == []
+
+
+def test_get_mem_mb_without_resource(monkeypatch) -> None:
+    """Memory helper should handle missing ``resource`` module."""
+    monkeypatch.setattr(solver, "resource", None)
+    assert solver._get_mem_mb() is None
+
+
+def test_solve_without_resource(monkeypatch) -> None:
+    """Solver should work even if ``resource`` is unavailable."""
+    params = SolveParams(
+        grid_w=6,
+        grid_h=6,
+        entrance_x=0,
+        entrance_w=1,
+        entrance_y=0,
+        entrance_h=1,
+        corridor_win=1,
+        max_iters=2,
+    )
+    monkeypatch.setattr(solver, "resource", None)
+    progress = Progress(interval=0)
+    result = solver.solve([], params, progress=progress)
     assert result["rooms"] == []

--- a/wands/model.py
+++ b/wands/model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 __all__ = [
     "Door",
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-@dataclass
+@dataclass(slots=True)
 class Door:
     """Door on a room wall leading into the corridor."""
 
@@ -23,7 +23,7 @@ class Door:
     pos_y: int
 
 
-@dataclass
+@dataclass(slots=True)
 class RoomPlacement:
     """A concrete placement of a room in the grid."""
 
@@ -33,10 +33,10 @@ class RoomPlacement:
     y: int
     w: int
     h: int
-    doors: List[Door] = field(default_factory=list)
+    doors: list[Door] = field(default_factory=list)
 
 
-@dataclass
+@dataclass(slots=True)
 class Entrance:
     """Fixed entrance block."""
 
@@ -46,7 +46,7 @@ class Entrance:
     y2: int = 50
 
 
-@dataclass
+@dataclass(slots=True)
 class RoomDef:
     """Definition of a room type to be placed."""
 
@@ -60,10 +60,10 @@ class RoomDef:
     step_h: int
     priority: int
     efficiency_factor: float
-    duplicate_id: Optional[str] = None
+    duplicate_id: str | None = None
 
 
-@dataclass
+@dataclass(slots=True)
 class SolveParams:
     """Solver parameters and fixed problem constants."""
 


### PR DESCRIPTION
## Zusammenfassung
- Implementiere vollständige Datenklassen für Türen, Raumplatzierungen, Eingänge und Solver-Parameter.
- Entferne OS-abhängige `resource`-Verwendung und ersetze sie durch eine optionale Speicherabfrage.
- Ergänze Tests für Datenmodelle und für Solver-Ausführung ohne `resource`.

## Testing
- `python -m docformatter --black --in-place --recursive .`
- `python -m ruff check --select I --fix .`
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m pydocstyle .`
- `python -m mypy .`
- `python -m vulture .`
- `python -m radon cc -s -a .`
- `python -m radon mi -s .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891a742c9548327aea5e77e321f0988