### PR TITLE
Außentürverbot standardisieren und CLI-Schalter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,3 +57,4 @@ Keine
 - 2025-08-11: AGENTS_Pruefung.md mit Prüfroutine hinzugefügt.
 - 2025-08-13: Solver setzt Seed- und Thread-Parameter.
 - 2025-08-14: Solver verbindet Korridorinseln über Pfad-Cut.
+- 2025-08-16: Validator verbietet Außentüren standardmäßig, CLI-Schalter hinzugefügt.

--- a/Prozess.md
+++ b/Prozess.md
@@ -82,6 +82,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 32. CP-SAT-Solver setzt Seed- und Threads-Parameter – ✔ erledigt
 33. Solver verbindet Korridorinseln über Pfad-Cut – ✔ erledigt
 34. Türheuristik mit Scoring für Türpositionen verbessern – ✔ erledigt
+35. Validator verbietet Außentüren standardmäßig, CLI-Schalter zum Zulassen – ✔ erledigt
 
 ## Parameter- & Optionsreferenz
 - Rastergröße `GRID_W=77`, `GRID_H=50` (Quelle: README.md#115-118)
@@ -100,6 +101,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - CLI: `--validate-only` (Quelle: Benutzeranweisung)
 - Ausgaben: `solution.json`, `solution.png`, `validation_report.json` (Quelle: AGENTS.md#14)
  - CLI: `--log-level`, `--log-format`, `--log-file` (Quelle: README.md#409-416)
+- CLI: `--allow-outside-doors` (Außentüren erlauben)
 
 ## Status
 | Aufgabe                                     | Status | Letzte Änderung        | Verantwortlich |
@@ -122,6 +124,7 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 | Solver nutzt Seed- und Thread-Parameter | ✔     | 2025-08-13T00:00:00Z   | Agent          |
 | Korridorinseln über Pfad-Cut verbinden | ✔     | 2025-08-14T00:00:00Z   | Agent          |
 | Türheuristik mit Scoring für Türpositionen verbessern | ✔     | 2025-08-15T00:00:00Z   | Agent          |
+| Außentüren standardmäßig verbieten, CLI-Schalter anbieten | ✔     | 2025-08-16T00:00:00Z   | Agent          |
 
 ## Change-Log
 - 2025-08-03T21:25:34Z – Initiale Prozessbeschreibung erstellt
@@ -149,3 +152,4 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - 2025-08-13T00:00:00Z – Solver setzt Seed- und Thread-Parameter
 - 2025-08-14T00:00:00Z – Solver verbindet Korridorinseln über Pfad-Cut
 - 2025-08-15T00:00:00Z – Türheuristik priorisiert breite Korridore bei Türwahl
+- 2025-08-16T00:00:00Z – Validator verbietet Außentüren standardmäßig, CLI-Schalter hinzugefügt

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ weitergereicht.
 - Eingang: Block **x=56..59**, **y=40..49** (4×10) gehört immer zum Gang.
 - Gang: Komplement aller Räume, **Breite ≥4** nach L∞ (**4×4-Fenster** vollständig Gang).
 - Konnektivität: genau **eine Gangkomponente** in **4-Nachbarschaft** inklusive Eingang.
-- Türen: liegen auf einer **Raumwand**, **nicht in Ecken**, öffnen in den Gang und sind vom Eingang aus erreichbar.
+- Türen: liegen auf einer **Raumwand**, **nicht in Ecken**, öffnen in den Gang, sind vom Eingang aus erreichbar und liegen **nicht am Außenrand** (außer am Eingang).
 - Räume: **rechteckig**, **wand-an-wand** erlaubt, **keine Überlappung**, vollständig im 77×50‑Grid.
 - Primäres Ziel: **Maximiere die Gesamtfläche aller Räume**.
 - Ausgaben: `solution.json`, `solution.png`, `validation_report.json`.
@@ -102,6 +102,7 @@ Die konkrete **Algorithmik** (Exact/CP-SAT/ILP/Flow/Graph/Heuristik) ist **frei*
 * **Nicht in Ecken:** Tür darf **nicht** den Schnittpunkt zweier Wände (Ecke) belegen.
 * **Tür → Gang:** Direkt „außerhalb“ dieses Wandsegments muss eine **Gangzelle** liegen (also die Tür öffnet **in den Gang**, nicht in einen Raum).
 * **Keine Raum-Durchreiche:** Es ist **verboten**, durch Räume zu gehen, um einen anderen Raum zu erreichen. Alle Erreichbarkeit verläuft **ausschließlich** über Gangzellen.
+* **Keine Außentüren:** Türen dürfen **nicht** direkt am Außenrand liegen – einzig der feste Eingang bildet die Ausnahme.
 
 **Formale Skizze (Türprüfung, exemplarisch):**
 
@@ -442,6 +443,7 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * `--progress-interval <sek>` (Default: `1`) – Mindestabstand zwischen Status-Updates
 * `--checkpoint <sek>` (optional) – speichert periodisch Zwischenstände
 * `--seed <int>` (Reproduzierbarkeit), `--time-limit <sek>` (optional), `--threads <n>` (optional)
+* `--allow-outside-doors` – erlaubt Türen am Außenrand (standardmäßig verboten)
 
 ### 16.2 Strukturierte Logs (Maschinen- & menschenlesbar)
 
@@ -525,3 +527,4 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * 2025-08-13: CP-SAT-Solver setzt Seed- und Thread-Parameter.
 * 2025-08-14: Solver verbindet Korridorinseln über Pfad-Cut.
 * 2025-08-15: Türheuristik wählt anhand von Scoring bessere Türpositionen.
+* 2025-08-16: Validator verbietet standardmäßig Außentüren; CLI-Schalter `--allow-outside-doors` hinzugefügt.

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -142,3 +142,23 @@ def test_validate_missing_door_fail() -> None:
     }
     report = validate(solution)
     assert report["doors"]["pass"] is False
+
+
+def test_validate_outside_door_fail() -> None:
+    """Doors directly at the outer boundary should fail by default."""
+    room = {
+        "id": "r",
+        "type": "T",
+        "x": 1,
+        "y": 10,
+        "w": 6,
+        "h": 6,
+        "doors": [{"side": "left", "pos_x": 1, "pos_y": 12}],
+    }
+    solution = {
+        "rooms": [room],
+        "entrance": {"x1": 56, "x2": 60, "y1": 40, "y2": 50},
+    }
+    report = validate(solution)
+    assert report["doors"]["pass"] is False
+    assert "Außenrand" in str(report["doors"]["info"])

--- a/wands/cli.py
+++ b/wands/cli.py
@@ -62,6 +62,11 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--checkpoint", type=float, default=0.0)
     parser.add_argument("--validate-only", action="store_true")
     parser.add_argument("--version", action="version", version=__version__)
+    parser.add_argument(
+        "--allow-outside-doors",
+        action="store_true",
+        help="Erlaubt Türen direkt am Außenrand",
+    )
     return parser
 
 
@@ -94,7 +99,9 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if args.validate_only:
         solution = json.loads(Path(args.config).read_text(encoding="utf8"))
-        report = validate(solution)
+        report = validate(
+            solution, require_no_outside_doors=not args.allow_outside_doors
+        )
         Path(args.report).write_text(json.dumps(report, indent=2), encoding="utf8")
         if prog:
             prog.heartbeat("validate")
@@ -133,7 +140,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         if now - last_checkpoint < args.checkpoint:
             return
         Path(args.out_json).write_text(json.dumps(sol, indent=2), encoding="utf8")
-        report = validate(sol)
+        report = validate(sol, require_no_outside_doors=not args.allow_outside_doors)
         Path(args.report).write_text(json.dumps(report, indent=2), encoding="utf8")
         render(sol, args.out_png)
         last_checkpoint = now
@@ -167,7 +174,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     if prog:
         prog.heartbeat("solve")
 
-    report = validate(solution)
+    report = validate(solution, require_no_outside_doors=not args.allow_outside_doors)
     Path(args.report).write_text(json.dumps(report, indent=2), encoding="utf8")
     if prog:
         prog.heartbeat("validate")

--- a/wands/validator.py
+++ b/wands/validator.py
@@ -189,9 +189,17 @@ def _check_doors(
 
 
 def validate(
-    solution: Dict, require_no_outside_doors: bool = False
+    solution: Dict, require_no_outside_doors: bool = True
 ) -> Dict[str, Dict[str, object]]:
-    """Validate ``solution`` and return a structured report."""
+    """Validate ``solution`` and return a structured report.
+
+    Parameters
+    ----------
+    solution:
+        Lösung, die geprüft werden soll.
+    require_no_outside_doors:
+        Wenn ``True`` (Standard), dürfen Türen nicht direkt ins Freie führen.
+    """
     grid, flags = build_grid(solution)
 
     corridor_cells = [


### PR DESCRIPTION
## Summary
- Außentüren werden nun standardmäßig vom Validator abgelehnt; mit `--allow-outside-doors` lässt sich dies über die CLI abschalten.
- Dokumentation und Prozessdateien vermerken das neue Außentürverbot.
- Regressionstest stellt sicher, dass Außentüren ohne Flag als Fehler gewertet werden.

## Testing
- `python -m docformatter --black --in-place --recursive .`
- `python -m ruff check --select I --fix .`
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m pydocstyle .`
- `python -m mypy .`
- `python -m vulture .`
- `python -m radon cc -s -a .`
- `python -m radon mi -s .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891ed5410f483278b64853514a3b674