### PR TITLE
Werkzeuge für Code-Prüfung ergänzen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,4 @@ Keine
 - 2025-08-14: Solver verbindet Korridorinseln über Pfad-Cut.
 - 2025-08-16: Validator verbietet Außentüren standardmäßig, CLI-Schalter hinzugefügt.
 - 2025-08-17: Datenmodell und CLI auf fixes 77×50-Raster reduziert, Lösung schreibt Grid-Konstanten.
+- 2025-08-18: Tooling-Abhängigkeiten docformatter, pydocstyle und types-PyYAML ergänzt.

--- a/Prozess.md
+++ b/Prozess.md
@@ -158,3 +158,4 @@ Dieses Projekt entwickelt ein Python-Programm, das auf einem 77×50‑Raster ein
 - 2025-08-15T00:00:00Z – Türheuristik priorisiert breite Korridore bei Türwahl
 - 2025-08-16T00:00:00Z – Validator verbietet Außentüren standardmäßig, CLI-Schalter hinzugefügt
 - 2025-08-17T00:00:00Z – Lösung ergänzt `grid_w`/`grid_h`, CLI entfernt Rasterparameter
+- 2025-08-18T00:00:00Z – Tooling-Abhängigkeiten docformatter, pydocstyle und types-PyYAML ergänzt

--- a/README.md
+++ b/README.md
@@ -529,3 +529,4 @@ Beispiel weiterer Einträge: **Storeroom**, **Graphics**, **Sound**, **MoCap**, 
 * 2025-08-15: Türheuristik wählt anhand von Scoring bessere Türpositionen.
 * 2025-08-16: Validator verbietet standardmäßig Außentüren; CLI-Schalter `--allow-outside-doors` hinzugefügt.
 * 2025-08-17: Datenmodell vereinfacht und CLI auf fixes 77×50-Raster reduziert; Lösung enthält `grid_w`/`grid_h`.
+* 2025-08-18: Tooling-Abhängigkeiten `docformatter`, `pydocstyle` und `types-PyYAML` ergänzt.

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ vulture==2.14
 xenon==0.9.3
 radon==6.0.1
 pre-commit==4.2.0
+docformatter==1.7.7
+pydocstyle==6.3.0
+types-PyYAML==6.0.12.20250516


### PR DESCRIPTION
## Zusammenfassung
- Ergänzt docformatter, pydocstyle und types-PyYAML in den Test- und Qualitätstools
- Dokumentation und Prozess-Logs um die neuen Abhängigkeiten erweitert

## Testanweisungen
- `python -m docformatter --black --in-place --recursive .`
- `python -m ruff check --select I --fix .`
- `python -m ruff format .`
- `python -m ruff check .`
- `python -m pydocstyle .`
- `python -m mypy .`
- `python -m vulture .`
- `python -m radon cc -s -a .`
- `python -m radon mi -s .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68920d04f0bc8327b3fa7b584250c7ce